### PR TITLE
Initialize ChannelFactory in LocoClientWrapper

### DIFF
--- a/teleop/utils/motion_switcher.py
+++ b/teleop/utils/motion_switcher.py
@@ -33,6 +33,7 @@ class MotionSwitcher:
 
 class LocoClientWrapper:
     def __init__(self):
+        ChannelFactoryInitialize(0)
         self.client = LocoClient()
         self.client.SetTimeout(0.0001)
         self.client.Init()


### PR DESCRIPTION
Fixed an error that occurred when using --input-mode=controller.