### PR TITLE
fix: extract BGR array for non-binocular camera

### DIFF
--- a/teleop/teleop_hand_and_arm.py
+++ b/teleop/teleop_hand_and_arm.py
@@ -403,7 +403,7 @@ if __name__ == '__main__':
                                 logger_mp.warning("Right wrist image is None!")
                     else:
                         if head_img is not None:
-                            colors[f"color_{0}"] = head_img
+                            colors[f"color_{0}"] = head_img.bgr
                         else:
                             logger_mp.warning("Head image is None!")
                         if camera_config['left_wrist_camera']['enable_zmq']:


### PR DESCRIPTION
## Description
- Fixes OpenCV imwrite error when `binocular: false` in camera config.
- Resolves "img is not a numpy array" when running teleoperation with the `--record` parameter.

## Changes
- Extract `head_img.bgr` numpy array instead of passing image object directly at line ~406 in `teleop_hand_and_arm.py`