### PR TITLE
fix: pass head_img.bgr (ndarray) to render_to_xr

### DIFF
--- a/teleop/teleop_hand_and_arm.py
+++ b/teleop/teleop_hand_and_arm.py
@@ -255,7 +255,8 @@ if __name__ == '__main__':
             time.sleep(0.033)
             if camera_config['head_camera']['enable_zmq'] and xr_need_local_img:
                 head_img = img_client.get_head_frame()
-                tv_wrapper.render_to_xr(head_img)
+                if head_img.bgr is not None:
+                    tv_wrapper.render_to_xr(head_img.bgr)
 
         logger_mp.info("---------------------🚀start Tracking🚀-------------------------")
         arm_ctrl.speed_gradual_max()
@@ -271,8 +272,8 @@ if __name__ == '__main__':
             if camera_config['head_camera']['enable_zmq']:
                 if args.record or xr_need_local_img:
                     head_img = img_client.get_head_frame()
-                if xr_need_local_img:
-                    tv_wrapper.render_to_xr(head_img)
+                if xr_need_local_img and head_img.bgr is not None:
+                    tv_wrapper.render_to_xr(head_img.bgr)
             if camera_config['left_wrist_camera']['enable_zmq']:
                 if args.record:
                     left_wrist_img = img_client.get_left_wrist_frame()


### PR DESCRIPTION
`render_to_xr()` expects a `numpy.ndarray`, but the two call sites in `teleop_hand_and_arm.py` pass the `TeleImage` wrapper returned by `get_head_frame()`. This crashes `cv2.cvtColor` in `televuer._xr_render_loop` whenever the ZMQ → Vuer path is used (head camera with `enable_webrtc: false`). Masked on the default WebRTC path because `render_to_xr()` early-returns there.

```diff
- tv_wrapper.render_to_xr(head_img)
+ if head_img.bgr is not None:
+     tv_wrapper.render_to_xr(head_img.bgr)
```

The `is not None` guard covers the startup window where the ZMQ subscriber is connected but the decoder hasn't produced a frame yet (`TeleImage.bgr` returns `None`).

Companion to #260, which made the same `TeleImage` → `.bgr` fix at the recording call site. Resolves the root cause behind #284.