### PR TITLE
Fix teleop input-mode docs and damp call

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ For more information, you can refer to [Official Documentation ](https://support
 (tv) unitree@Host:~$ cd xr_teleoperate
 # Shallow clone submodule
 (tv) unitree@Host:~/xr_teleoperate$ git submodule update --init --depth 1
+# Install supplemental Python dependencies listed by this repo
+(tv) unitree@Host:~/xr_teleoperate$ pip install -r requirements.txt
 ```
 
 ```bash
@@ -273,7 +275,7 @@ Assuming hand tracking with G1(29 DoF) + Dex3 in simulation with recording:
 
 ```bash
 (tv) unitree@Host:~$ cd ~/xr_teleoperate/teleop/
-(tv) unitree@Host:~/xr_teleoperate/teleop/$ python teleop_hand_and_arm.py --xr-mode=hand --arm=G1_29 --ee=dex3 --sim --record
+(tv) unitree@Host:~/xr_teleoperate/teleop/$ python teleop_hand_and_arm.py --input-mode=hand --arm=G1_29 --ee=dex3 --sim --record
 # Simplified (defaults apply):
 (tv) unitree@Host:~/xr_teleoperate/teleop/$ python teleop_hand_and_arm.py --ee=dex3 --sim --record
 ```

--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -122,7 +122,7 @@ Ubuntu 20.04と22.04でテスト済みです。他のOSでは設定が異なる�
 # Install dex-retargeting submodule
 (tv) unitree@Host:~/xr_teleoperate/teleop/televuer$ cd ../robot_control/dex-retargeting/
 (tv) unitree@Host:~/xr_teleoperate/teleop/robot_control/dex-retargeting$ pip install -e .
-# Install additional dependencies required by this repo
+# Install supplemental Python dependencies listed by this repo
 (tv) unitree@Host:~/xr_teleoperate/teleop/robot_control/dex-retargeting$ cd ../../../
 (tv) unitree@Host:~/xr_teleoperate$ pip install -r requirements.txt
 ```
@@ -177,7 +177,7 @@ G1(29 DoF)とDex3ハンド構成でシミュレーションを起動:
 
 | ⚙️ パラメータ |                📜 説明                |                         🔘 オプション                         | 📌 デフォルト |
 | :----------: | :----------------------------------: | :----------------------------------------------------------: | :----------: |
-| `--xr-mode`  |           XR入力モード選択           | `hand` (**ハンドトラッキング**) `controller` (**コントローラートラッキング**) |    `hand`    |
+| `--input-mode`  |           XR入力モード選択           | `hand` (**ハンドトラッキング**) `controller` (**コントローラートラッキング**) |    `hand`    |
 |   `--arm`    | ロボットアームタイプ選択 (0. 📖 参照) |                 `G1_29` `G1_23` `H1_2` `H1`                  |   `G1_29`    |
 |    `--ee`    |   エンドエフェクタ選択 (0. 📖 参照)   |                   `dex1` `dex3` `inspire1`                   |     none     |
 
@@ -194,7 +194,7 @@ G1(29 DoF) + Dex3でハンドトラッキング、シミュレーション、記
 
 ```bash
 (tv) unitree@Host:~$ cd ~/xr_teleoperate/teleop/
-(tv) unitree@Host:~/xr_teleoperate/teleop/$ python teleop_hand_and_arm.py --xr-mode=hand --arm=G1_29 --ee=dex3 --sim --record
+(tv) unitree@Host:~/xr_teleoperate/teleop/$ python teleop_hand_and_arm.py --input-mode=hand --arm=G1_29 --ee=dex3 --sim --record
 # 簡略化（デフォルト適用）:
 (tv) unitree@Host:~/xr_teleoperate/teleop/$ python teleop_hand_and_arm.py --ee=dex3 --sim --record
 ```

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -183,7 +183,7 @@ build  cert.pem  key.pem  LICENSE  pyproject.toml  README.md  rootCA.key  rootCA
 ```
 
 ```bash
-# 安装本仓库所需的其他依赖库
+# 安装 requirements.txt 中列出的补充 Python 依赖
 (tv) unitree@Host:~/xr_teleoperate/teleop/robot_control/dex-retargeting$ cd ../../../
 (tv) unitree@Host:~/xr_teleoperate$ pip install -r requirements.txt
 ```
@@ -296,7 +296,7 @@ build  cert.pem  key.pem  LICENSE  pyproject.toml  README.md  rootCA.key  rootCA
 
 ```bash
 (tv) unitree@Host:~$ cd ~/xr_teleoperate/teleop/
-(tv) unitree@Host:~/xr_teleoperate/teleop/$ python teleop_hand_and_arm.py --xr-mode=hand --arm=G1_29 --ee=dex3 --sim --record
+(tv) unitree@Host:~/xr_teleoperate/teleop/$ python teleop_hand_and_arm.py --input-mode=hand --arm=G1_29 --ee=dex3 --sim --record
 # 实际上，由于一些参数存在默认值，该命令也可简化为：
 (tv) unitree@Host:~/xr_teleoperate/teleop/$ python teleop_hand_and_arm.py --ee=dex3 --sim --record
 ```

--- a/teleop/teleop_hand_and_arm.py
+++ b/teleop/teleop_hand_and_arm.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     # basic control parameters
     parser.add_argument('--frequency', type = float, default = 30.0, help = 'control and record \'s frequency')
-    parser.add_argument('--input-mode', type=str, choices=['hand', 'controller'], default='hand', help='Select XR device input tracking source')
+    parser.add_argument('--input-mode', '--xr-mode', dest='input_mode', type=str, choices=['hand', 'controller'], default='hand', help='Select XR device input tracking source')
     parser.add_argument('--display-mode', type=str, choices=['immersive', 'ego', 'pass-through'], default='immersive', help='Select XR device display mode')
     parser.add_argument('--arm', type=str, choices=['G1_29', 'G1_23', 'H1_2', 'H1', 'H2'], default='G1_29', help='Select arm controller')
     parser.add_argument('--ee', type=str, choices=['dex1', 'dex3', 'inspire_ftp', 'inspire_dfx', 'brainco'], help='Select end effector controller')
@@ -349,12 +349,13 @@ if __name__ == '__main__':
                     START = False
                     STOP = True
                 # command robot to enter damping mode. soft emergency stop function
-                if tele_data.left_ctrl_thumbstick and tele_data.right_ctrl_thumbstick:
-                    loco_wrapper.Damp()
+                elif tele_data.left_ctrl_thumbstick and tele_data.right_ctrl_thumbstick:
+                    loco_wrapper.Enter_Damp_Mode()
                 # https://github.com/unitreerobotics/xr_teleoperate/issues/135, control, limit velocity to within 0.3
-                loco_wrapper.Move(-tele_data.left_ctrl_thumbstickValue[1] * 0.3,
-                                  -tele_data.left_ctrl_thumbstickValue[0] * 0.3,
-                                  -tele_data.right_ctrl_thumbstickValue[0]* 0.3)
+                else:
+                    loco_wrapper.Move(-tele_data.left_ctrl_thumbstickValue[1] * 0.3,
+                                      -tele_data.left_ctrl_thumbstickValue[0] * 0.3,
+                                      -tele_data.right_ctrl_thumbstickValue[0]* 0.3)
 
             # get current robot state data.
             current_lr_arm_q  = arm_ctrl.get_current_dual_arm_q()


### PR DESCRIPTION
## Summary

- Update README launch examples to use the current `--input-mode` flag.
- Keep `--xr-mode` as a backward-compatible alias for existing commands and older docs/scripts.
- Fix the controller soft-stop path to call `LocoClientWrapper.Enter_Damp_Mode()` instead of a non-existent `Damp()` method.
- Keep stop/damp commands mutually exclusive with locomotion `Move(...)` in the same control-loop iteration.
- Document `requirements.txt` installation as supplemental Python dependencies in the README install flow.

## Why

`teleop_hand_and_arm.py` documents and uses `args.input_mode`, but the launch examples still used `--xr-mode`, which makes the documented simulation command fail argument parsing. Separately, controller motion mode attempted to call `loco_wrapper.Damp()`, but the wrapper exposes `Enter_Damp_Mode()`, so pressing both thumbsticks for damping would raise `AttributeError` instead of entering damp mode. The high-level controller branch now also avoids immediately sending a movement command after stop or damp is requested.

The English README also skipped the root `requirements.txt` install step even though the translated READMEs include it. This PR adds the English step and clarifies that those packages are supplemental to the conda, submodule, and SDK setup.

## Validation

- `python3 -m compileall -q teleop`
- `git diff --check`
- `clawpatch ci --include-dirty --since origin/main --jobs 1 --reasoning-effort high` using clawpatch `d5e764d`: 0 findings after the critical-review amendments
- `clawpatch review --include-dirty --since origin/main --mode deslopify --jobs 1`: no touched-feature cleanup findings

Hardware/simulation runtime was not exercised in this environment.